### PR TITLE
fixing Redd::Objects::Subreddit#admin_edit

### DIFF
--- a/lib/redd/objects/subreddit.rb
+++ b/lib/redd/objects/subreddit.rb
@@ -224,14 +224,22 @@ module Redd
           public_description public_traffic show_cname_sidebar show_media
           spam_comments spam_links spam_selfposts submit_link_label
           submit_text submit_text_label title type wiki_edit_age
-          wiki_edit_karma wikimode header-title
+          wiki_edit_karma wikimode header-title link_type
         )
 
         if required_attributes.all? { |key| attributes.key?(key) }
           params.merge!(attributes)
         else
           current = admin_about
-          current.delete(:kind)
+          current.delete_if {|key, value| :kind == key }
+          if !current[:link_type] && current[:content_options]
+            current[:link_type] = current[:content_options]
+            current.delete_if {|key, value| :content_options == key }
+          end
+          if !current[:type] && current[:subreddit_type]
+            current[:type] = current[:subreddit_type]
+            current.delete_if {|key, value| :subreddit_type == key }
+          end
           complete = current.merge(attributes)
           params.merge!(complete)
         end


### PR DESCRIPTION
There seems to be two issues:

- When you call `Redd::Objects::Subreddit#admin_edit()` with not fulfilled attributes, it calls `Redd::Objects::Subreddit#admin_about()` internally, then trying to clean up the attributes.  The returned attributes object there is `Redd::Objects::Base` which delegates `#delete()` to `Redd::Clients::Base#delete()`.  So, the `delete()` call on the original line 234 is supposed to call `Hash#delete()` but it was calling `Redd::Clients::Base#delete()`, which is not ideal.
- Also, a few testing on admin_edit, I found out some Reddit API discrepancy…  even tho `get("/r/#{display_name}/about/edit.json")` gives `:content_options` and `:subreddit_type`, `post("/api/site_admin")` requires them as `:link_type` and `:type`.

Both issues, I don't know what is the best way to fix them, so I patched up (and feel a bit dirty).  Feel free to abandon my code to fix them cleaner!