### PR TITLE
Fix broken instance variable @last_request

### DIFF
--- a/lib/redd/rate_limit.rb
+++ b/lib/redd/rate_limit.rb
@@ -62,7 +62,7 @@ module Redd
     # Update necessary info with each request.
     # @param [Faraday::Response] response The response to the request made.
     def update!(response)
-      @last_request = Time.now
+      @last_request_time = Time.now
       %w(used remaining reset).each do |type|
         value = response.headers["x-ratelimit-#{type}"]
         instance_variable_set("@#{type}", value.to_i) unless value.nil?


### PR DESCRIPTION
Line 65 defined @last_request, which went unused, and line 80 referenced @last_request_time, which didn't exist, causing an error.